### PR TITLE
Fix timer start on task creation

### DIFF
--- a/tasks/templates/tasks/weekly_tasks.html
+++ b/tasks/templates/tasks/weekly_tasks.html
@@ -304,9 +304,6 @@
                 <input type="number" name="estimated_seconds" min="0" max="59" placeholder="Seconds">
             </div>
 
-            <div class="form-group">
-                <label>{{ form.start_timer }} Start timer now</label>
-            </div>
 
             <button type="submit" class="save-btn">Save Task</button>
             <button type="button" class="delete-btn" onclick="toggleForm('new-task-form')">Cancel</button>

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -46,9 +46,8 @@ def daily_tasks(request):
 
             task.save()
 
-            if form.cleaned_data.get('start_timer'):
-                if total_seconds > 0:
-                    Timer.objects.create(
+            if total_seconds > 0:
+                Timer.objects.create(
                     user=request.user,
                     task=task,
                     start_time=timezone.now(),


### PR DESCRIPTION
## Summary
- start timer automatically when a task with an estimate is created
- remove unused `start_timer` field reference from weekly task template

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6879b4efdb9883318fb7e9ea3225a720