### PR TITLE
Improve task form layout and weekly completion view

### DIFF
--- a/tasks/templates/tasks/daily_tasks.html
+++ b/tasks/templates/tasks/daily_tasks.html
@@ -272,6 +272,7 @@
         </div>
     </form>
 
+
 <h2 class="section-title">Today's Tasks</h2>
     {% for task in incomplete_tasks %}
         <div class="task-card {% if task.is_completed %}completed{% endif %}">
@@ -300,11 +301,12 @@
                         <button type="submit" class="delete-btn">Delete</button>
                     </form>
                 </div>
-                <div id="edit-form-{{ task.id }}" class="edit-form">
+                <div id="edit-form-{{ task.id }}" class="edit-form task-form-container">
                     <form method="post" action="{% url 'edit_task' task.id %}">
                         {% csrf_token %}
                         {{ edit_forms|dict_get:task.id|safe }}
                         <button type="submit" class="save-btn">Save Changes</button>
+                        <button type="button" class="delete-btn" onclick="toggleForm('edit-form-{{ task.id }}')">Cancel</button>
                     </form>
                 </div>
             </div>
@@ -340,11 +342,12 @@
                         <button type="submit" class="delete-btn">Delete</button>
                     </form>
                 </div>
-                <div id="edit-form-{{ task.id }}" class="edit-form">
+                <div id="edit-form-{{ task.id }}" class="edit-form task-form-container">
                     <form method="post" action="{% url 'edit_task' task.id %}">
                         {% csrf_token %}
                         {{ edit_forms|dict_get:task.id|safe }}
                         <button type="submit" class="save-btn">Save Changes</button>
+                        <button type="button" class="delete-btn" onclick="toggleForm('edit-form-{{ task.id }}')">Cancel</button>
                     </form>
                 </div>
             </div>

--- a/tasks/templates/tasks/weekly_tasks.html
+++ b/tasks/templates/tasks/weekly_tasks.html
@@ -341,11 +341,12 @@
                         </form>
                     </div>
 
-                    <div id="edit-form-{{ task.id }}" class="edit-form">
+                    <div id="edit-form-{{ task.id }}" class="edit-form task-form-container">
                         <form method="post" action="{% url 'edit_task' task.id %}">
                             {% csrf_token %}
                             {{ edit_forms|dict_get:task.id|safe }}
                             <button type="submit" class="save-btn">Save Changes</button>
+                            <button type="button" class="delete-btn" onclick="toggleForm('edit-form-{{ task.id }}')">Cancel</button>
                         </form>
                     </div>
                 </div>
@@ -357,6 +358,47 @@
                 </form>
             </div>
         {% endfor %}
+    {% endfor %}
+
+    <h2 class="section-title">Completed Tasks</h2>
+    {% for task in completed_tasks %}
+        <div class="task-card completed">
+            <div class="task-details">
+                <div class="category-symbol" style="color: {{ task.category_color }}">ᯓ★ˎˊ˗</div>
+                <div class="task-title">{{ task.title }}</div>
+                <div class="task-desc">{{ task.description }}</div>
+                <div class="date-info">
+                    {% if task.deadline %}Due: {{ task.deadline|date:"F j, Y" }}{% endif %}
+                    {% if task.goal_date %} | Goal: {{ task.goal_date|date:"F j, Y" }}{% endif %}
+                    {% if task.category %} | Category: {{ task.category }}{% endif %}
+                    {% if task.estimated_time %} | Est: {{ task.estimated_time|seconds_to_hms }}{% endif %}
+                    | Spent: {{ spent_times|dict_get:task.id|seconds_to_hms }}
+                </div>
+                <div class="action-buttons" style="margin-top: 10px;">
+                    <button class="edit-btn" onclick="toggleForm('edit-form-{{ task.id }}')">Edit</button>
+                    <form method="post" action="{% url 'delete_task' task.id %}" style="display:inline;">
+                        {% csrf_token %}
+                        <button type="submit" class="delete-btn">Delete</button>
+                    </form>
+                </div>
+                <div id="edit-form-{{ task.id }}" class="edit-form task-form-container">
+                    <form method="post" action="{% url 'edit_task' task.id %}">
+                        {% csrf_token %}
+                        {{ edit_forms|dict_get:task.id|safe }}
+                        <button type="submit" class="save-btn">Save Changes</button>
+                        <button type="button" class="delete-btn" onclick="toggleForm('edit-form-{{ task.id }}')">Cancel</button>
+                    </form>
+                </div>
+            </div>
+            <form method="post" action="{% url 'toggle_task_complete' task.id %}">
+                {% csrf_token %}
+                <button type="submit" class="check-circle completed" title="Mark as incomplete">
+                    <span>✔</span>
+                </button>
+            </form>
+        </div>
+    {% empty %}
+        <p>No tasks completed this week.</p>
     {% endfor %}
 </div>
 

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -142,8 +142,11 @@ def weekly_tasks(request):
     # Group by day for incomplete tasks
     weekdays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
     tasks_by_day = {day: [] for day in weekdays}
+    completed_tasks = []
     for task in all_tasks:
-        if not task.is_completed:
+        if task.is_completed:
+            completed_tasks.append(task)
+        else:
             weekday_name = task.date.strftime('%A')
             tasks_by_day[weekday_name].append(task)
 
@@ -170,6 +173,7 @@ def weekly_tasks(request):
         'end_date': end_of_week,
         'tasks_by_day': tasks_by_day,
         'all_tasks': all_tasks,
+        'completed_tasks': completed_tasks,
         'form': form,
         'edit_forms': edit_forms,
         'categories': categories,


### PR DESCRIPTION
## Summary
- style edit forms like the add form
- keep the Add Task form near the top of the daily page
- display completed weekly tasks instead of hiding them

## Testing
- `python manage.py test`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6879e56f231c8331ae52eea9acf12124