### PR TITLE
Add week navigation and timer improvements

### DIFF
--- a/tasks/templates/tasks/daily_tasks.html
+++ b/tasks/templates/tasks/daily_tasks.html
@@ -163,6 +163,12 @@
         .timer-display {
             margin-top: 5px;
             font-size: 13px;
+            background-color: #eef0f5;
+            color: #000;
+            padding: 4px 8px;
+            border-radius: 8px;
+            text-align: center;
+            display: inline-block;
         }
 
         .time-remain.expired {
@@ -171,7 +177,8 @@
 
         .overtime {
             color: red;
-            margin-left: 10px;
+            margin-top: 5px;
+            display: block;
         }
 
         .edit-form {
@@ -288,10 +295,12 @@
                 {{ form.goal_date }}
             </p>
 
-            <p>
-                <label for="{{ form.estimated_time.id_for_label }}">Estimated Time of Completion in Minutes:</label><br>
-                {{ form.estimated_time }}
-            </p>
+            <div class="time-input-group">
+                <label style="margin-right: 10px;">Estimated Duration:</label>
+                <input type="number" name="estimated_hours" min="0" placeholder="Hours">
+                <input type="number" name="estimated_minutes" min="0" max="59" placeholder="Minutes">
+                <input type="number" name="estimated_seconds" min="0" max="59" placeholder="Seconds">
+            </div>
 
             <p>
                 <label for="{{ form.category.id_for_label }}">Category:</label><br>
@@ -364,11 +373,12 @@
                     </form>
                 </div>
 
-                <div id="edit-form-{{ task.id }}" class="edit-form" style="display: none;">
+                <div id="edit-form-{{ task.id }}" class="edit-form task-form-container" style="display: none;">
                     <form method="post" action="{% url 'edit_task' task.id %}">
                         {% csrf_token %}
                         {{ edit_forms|dict_get:task.id|safe }}
                         <button type="submit" class="save-btn">Save Changes</button>
+                        <button type="button" class="delete-btn" onclick="toggleForm('edit-form-{{ task.id }}')">Cancel</button>
                     </form>
                 </div>
 
@@ -378,8 +388,9 @@
                     <button onclick="pauseTimer({{ task.id }})" class="add-task-btn">Pause</button>
                     <button onclick="stopTimer({{ task.id }}, {{ task.estimated_time|default:0 }})" class="delete-btn">Stop</button>
                     <div id="timer-display-{{ task.id }}" class="timer-display" style="margin-top: 5px;">
-                        Time Remaining: {{ task.estimated_time|default:"00" }}:00:00
+                        {{ task.estimated_time|seconds_to_hms }}
                     </div>
+                    <span id="overtime-display-{{ task.id }}" class="overtime" style="display:none;"></span>
                 </div>
             </div>
         {% empty %}
@@ -422,11 +433,12 @@
                         </form>
                     </div>
 
-                    <div id="edit-form-{{ task.id }}" class="edit-form" style="display: none;">
+                    <div id="edit-form-{{ task.id }}" class="edit-form task-form-container" style="display: none;">
                         <form method="post" action="{% url 'edit_task' task.id %}">
                             {% csrf_token %}
                             {{ edit_forms|dict_get:task.id|safe }}
                             <button type="submit" class="save-btn">Save Changes</button>
+                            <button type="button" class="delete-btn" onclick="toggleForm('edit-form-{{ task.id }}')">Cancel</button>
                         </form>
                     </div>
                 </div>
@@ -455,7 +467,7 @@
     }
 
     // Timer state and intervals for countdown timers
-    const timers = {};  // taskId: {remainingSeconds, intervalId}
+    const timers = {};  // taskId: {remainingSeconds, intervalId, notified}
 
     // Load timer states from localStorage
     function loadTimers() {
@@ -467,7 +479,10 @@
     function saveTimers() {
         const state = {};
         for (const taskId in timers) {
-            state[taskId] = { remainingSeconds: timers[taskId].remainingSeconds };
+            state[taskId] = {
+                remainingSeconds: timers[taskId].remainingSeconds,
+                notified: timers[taskId].notified
+            };
         }
         localStorage.setItem('countdownTimers', JSON.stringify(state));
     }
@@ -475,24 +490,33 @@
     // Update timer display for a task
     function updateDisplay(taskId) {
         const display = document.getElementById(`timer-display-${taskId}`);
+        const overtimeEl = document.getElementById(`overtime-display-${taskId}`);
         if (!display) return;
         const remaining = timers[taskId]?.remainingSeconds ?? 0;
-        if (remaining > 0) {
-            display.textContent = `Time Remaining: ${formatTime(remaining)}`;
+        if (remaining >= 0) {
+            display.textContent = formatTime(remaining);
             display.classList.remove('expired');
+            if (overtimeEl) overtimeEl.style.display = 'none';
         } else {
-            display.textContent = "Time's Up!";
-            display.classList.add('expired');
+            if (!timers[taskId].notified) {
+                alert(`Task ${taskId} time is up!`);
+                timers[taskId].notified = true;
+                display.classList.add('expired');
+                display.textContent = '00:00:00';
+                if (overtimeEl) overtimeEl.style.display = 'block';
+            }
+            if (overtimeEl) overtimeEl.textContent = 'Overtime: ' + formatTime(-remaining);
         }
     }
 
     // Start countdown timer
-    function startTimer(taskId, estMinutes) {
+    function startTimer(taskId, estSeconds) {
         if (timers[taskId]?.intervalId) return; // Already running
 
         if (!timers[taskId]) {
             timers[taskId] = {
-                remainingSeconds: estMinutes * 60
+                remainingSeconds: estSeconds,
+                notified: false
             };
         }
 
@@ -501,12 +525,6 @@
         timers[taskId].intervalId = setInterval(() => {
             timers[taskId].remainingSeconds--;
             updateDisplay(taskId);
-
-            if (timers[taskId].remainingSeconds <= 0) {
-                clearInterval(timers[taskId].intervalId);
-                timers[taskId].intervalId = null;
-                alert(`Task ${taskId} time is up!`);
-            }
             saveTimers();
         }, 1000);
 
@@ -523,13 +541,13 @@
     }
 
     // Stop countdown timer and reset
-function stopTimer(taskId, estMinutes) {
+function stopTimer(taskId, estSeconds) {
     if (timers[taskId]?.intervalId) {
         clearInterval(timers[taskId].intervalId);
     }
 
     // Calculate elapsed time before resetting
-    const originalSeconds = estMinutes * 60;
+    const originalSeconds = estSeconds;
     const remaining = timers[taskId]?.remainingSeconds ?? originalSeconds;
     const elapsed = originalSeconds - remaining;
 
@@ -540,8 +558,11 @@ function stopTimer(taskId, estMinutes) {
     // Reset timer state
     timers[taskId] = {
         remainingSeconds: originalSeconds,
-        intervalId: null
+        intervalId: null,
+        notified: false
     };
+    const overEl = document.getElementById(`overtime-display-${taskId}`);
+    if (overEl) overEl.style.display = 'none';
 
     updateDisplay(taskId);
     saveTimers();
@@ -552,14 +573,18 @@ function stopTimer(taskId, estMinutes) {
     window.addEventListener('load', () => {
         const storedTimers = loadTimers();
         for (const taskId in storedTimers) {
-            timers[taskId] = { remainingSeconds: storedTimers[taskId].remainingSeconds, intervalId: null };
+            timers[taskId] = {
+                remainingSeconds: storedTimers[taskId].remainingSeconds,
+                intervalId: null,
+                notified: storedTimers[taskId].notified
+            };
             updateDisplay(taskId);
         }
     });
 
 // Get elapsed time in seconds for a task
-    function getElapsedTime(taskId, estMinutes) {
-        const originalSeconds = estMinutes * 60;
+    function getElapsedTime(taskId, estSeconds) {
+        const originalSeconds = estSeconds;
         const remaining = timers[taskId]?.remainingSeconds ?? originalSeconds;
         const elapsed = originalSeconds - remaining;
     return elapsed; // in seconds

--- a/tasks/templates/tasks/weekly_tasks.html
+++ b/tasks/templates/tasks/weekly_tasks.html
@@ -159,9 +159,23 @@
             font-size: 16px;
         }
 
+        .timer-section {
+            text-align: center;
+            margin-top: 10px;
+        }
+
+        .timer-label {
+            font-weight: bold;
+        }
+
         .timer-display {
             margin-top: 5px;
             font-size: 13px;
+            background-color: #eef0f5;
+            color: #000;
+            padding: 4px 8px;
+            border-radius: 8px;
+            display: inline-block;
         }
 
         .time-remain.expired {
@@ -170,7 +184,8 @@
 
         .overtime {
             color: red;
-            margin-left: 10px;
+            margin-top: 5px;
+            display: block;
         }
 
         .edit-form {
@@ -311,11 +326,18 @@
     </div>
 
     {% for day, tasks in tasks_by_day.items %}
-        <div class="day-header">{{ day }}</div>
+        <div class="day-header">{{ day }} - {{ week_day_dates|dict_get:day|date:"F j, Y" }}</div>
         {% for task in tasks %}
             <div class="task-card {% if task.is_completed %}completed{% endif %}">
+                <form method="post" action="{% url 'toggle_task_complete' task.id %}">
+                    {% csrf_token %}
+                    <button type="submit" class="check-circle {% if task.is_completed %}completed{% endif %}" title="Toggle complete">
+                        {% if task.is_completed %}<span>✔</span>{% endif %}
+                    </button>
+                </form>
+
+                <div class="category-symbol" style="color: {{ task.category_color }}">ᯓ★ˎˊ˗</div>
                 <div class="task-details">
-                    <div class="category-symbol" style="color: {{ task.category_color }}">ᯓ★ˎˊ˗</div>
                     <div class="task-title">{{ task.title }}</div>
                     <div class="task-desc">{{ task.description }}</div>
                     <div class="date-info">
@@ -326,7 +348,7 @@
                         {% with info=running_timers|dict_get:task.id %}
                             {% if info %}
                                 <div class="timer-display">
-                                    Time Remaining: <span id="timer-{{ task.id }}" class="time-remain"></span>
+                                    <span id="timer-{{ task.id }}" class="time-remain"></span>
                                     <span id="overtime-{{ task.id }}" class="overtime" style="display:none;"></span>
                                 </div>
                             {% endif %}
@@ -349,13 +371,18 @@
                             <button type="button" class="delete-btn" onclick="toggleForm('edit-form-{{ task.id }}')">Cancel</button>
                         </form>
                     </div>
+
+                    <div class="timer-section">
+                        <div class="timer-label">Time Remaining</div>
+                        <div id="timer-display-{{ task.id }}" class="timer-display">{{ task.estimated_time|seconds_to_hms }}</div>
+                        <span id="overtime-display-{{ task.id }}" class="overtime" style="display:none;"></span>
+                        <div class="action-buttons" style="margin-top: 10px;">
+                            <button onclick="startTimer({{ task.id }}, {{ task.estimated_time|default:0 }})" class="add-task-btn">Start</button>
+                            <button onclick="pauseTimer({{ task.id }})" class="add-task-btn">Pause</button>
+                            <button onclick="stopTimer({{ task.id }}, {{ task.estimated_time|default:0 }})" class="delete-btn">Stop</button>
+                        </div>
+                    </div>
                 </div>
-                <form method="post" action="{% url 'toggle_task_complete' task.id %}">
-                    {% csrf_token %}
-                    <button type="submit" class="check-circle {% if task.is_completed %}completed{% endif %}" title="Toggle complete">
-                        {% if task.is_completed %}<span>✔</span>{% endif %}
-                    </button>
-                </form>
             </div>
         {% endfor %}
     {% endfor %}
@@ -363,8 +390,14 @@
     <h2 class="section-title">Completed Tasks</h2>
     {% for task in completed_tasks %}
         <div class="task-card completed">
+            <form method="post" action="{% url 'toggle_task_complete' task.id %}">
+                {% csrf_token %}
+                <button type="submit" class="check-circle completed" title="Mark as incomplete">
+                    <span>✔</span>
+                </button>
+            </form>
+            <div class="category-symbol" style="color: {{ task.category_color }}">ᯓ★ˎˊ˗</div>
             <div class="task-details">
-                <div class="category-symbol" style="color: {{ task.category_color }}">ᯓ★ˎˊ˗</div>
                 <div class="task-title">{{ task.title }}</div>
                 <div class="task-desc">{{ task.description }}</div>
                 <div class="date-info">
@@ -390,16 +423,14 @@
                     </form>
                 </div>
             </div>
-            <form method="post" action="{% url 'toggle_task_complete' task.id %}">
-                {% csrf_token %}
-                <button type="submit" class="check-circle completed" title="Mark as incomplete">
-                    <span>✔</span>
-                </button>
-            </form>
         </div>
     {% empty %}
         <p>No tasks completed this week.</p>
     {% endfor %}
+</div>
+
+<div style="text-align:center; margin-top: 20px;">
+    <a href="?week={{ week_offset|add:1 }}" class="add-task-btn">Next Week</a>
 </div>
 
 </div>
@@ -452,6 +483,86 @@
         for (const [id, data] of Object.entries(runningTimers)) {
             const el = document.getElementById('timer-' + id);
             if (el) startCountdown(el, { ...data, id: id });
+        }
+    });
+
+    // Local countdown timers for Start/Pause/Stop buttons
+    const timers = {};
+
+    function loadTimers() {
+        const stored = localStorage.getItem('weeklyCountdowns');
+        return stored ? JSON.parse(stored) : {};
+    }
+
+    function saveTimers() {
+        const state = {};
+        for (const id in timers) {
+            state[id] = { remainingSeconds: timers[id].remainingSeconds, notified: timers[id].notified };
+        }
+        localStorage.setItem('weeklyCountdowns', JSON.stringify(state));
+    }
+
+    function updateDisplay(id) {
+        const remEl = document.getElementById('timer-display-' + id) || document.getElementById('timer-' + id);
+        const overEl = document.getElementById('overtime-display-' + id) || document.getElementById('overtime-' + id);
+        if (!remEl) return;
+        const remaining = timers[id]?.remainingSeconds ?? 0;
+        if (remaining >= 0) {
+            remEl.textContent = formatTime(remaining);
+            remEl.classList.remove('expired');
+            if (overEl) overEl.style.display = 'none';
+        } else {
+            if (!timers[id].notified) {
+                alert('Task ' + id + ' time is up!');
+                timers[id].notified = true;
+                remEl.classList.add('expired');
+                remEl.textContent = '00:00:00';
+                if (overEl) overEl.style.display = 'block';
+            }
+            if (overEl) overEl.textContent = 'Overtime: ' + formatTime(-remaining);
+        }
+    }
+
+    function startTimer(id, est) {
+        if (timers[id]?.intervalId) return;
+
+        if (!timers[id]) {
+            timers[id] = { remainingSeconds: est, intervalId: null, notified: false };
+        }
+
+        updateDisplay(id);
+        timers[id].intervalId = setInterval(() => {
+            timers[id].remainingSeconds--;
+            updateDisplay(id);
+            saveTimers();
+        }, 1000);
+        saveTimers();
+    }
+
+    function pauseTimer(id) {
+        if (timers[id]?.intervalId) {
+            clearInterval(timers[id].intervalId);
+            timers[id].intervalId = null;
+            saveTimers();
+        }
+    }
+
+    function stopTimer(id, est) {
+        if (timers[id]?.intervalId) {
+            clearInterval(timers[id].intervalId);
+        }
+        timers[id] = { remainingSeconds: est, intervalId: null, notified: false };
+        const overEl = document.getElementById('overtime-display-' + id) || document.getElementById('overtime-' + id);
+        if (overEl) overEl.style.display = 'none';
+        updateDisplay(id);
+        saveTimers();
+    }
+
+    window.addEventListener('load', () => {
+        const stored = loadTimers();
+        for (const id in stored) {
+            timers[id] = { remainingSeconds: stored[id].remainingSeconds, intervalId: null, notified: stored[id].notified };
+            updateDisplay(id);
         }
     });
 </script>

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -114,7 +114,8 @@ def daily_tasks(request):
 @login_required
 def weekly_tasks(request):
     today = date.today()
-    start_of_week = today - timedelta(days=today.weekday())  # Monday
+    week_offset = int(request.GET.get('week', 0))
+    start_of_week = today - timedelta(days=today.weekday()) + timedelta(weeks=week_offset)  # Monday
     end_of_week = start_of_week + timedelta(days=6)          # Sunday
 
     search_query = request.GET.get('search', '').strip()
@@ -159,6 +160,7 @@ def weekly_tasks(request):
 
     weekdays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
     tasks_by_day = {day: [] for day in weekdays}
+    week_day_dates = {day: start_of_week + timedelta(days=i) for i, day in enumerate(weekdays)}
     completed_tasks = []
     for task in all_tasks:
         if task.is_completed:
@@ -189,6 +191,7 @@ def weekly_tasks(request):
         'start_date': start_of_week,
         'end_date': end_of_week,
         'tasks_by_day': tasks_by_day,
+        'week_day_dates': week_day_dates,
         'all_tasks': all_tasks,
         'completed_tasks': completed_tasks,
         'form': form,
@@ -199,6 +202,7 @@ def weekly_tasks(request):
         'spent_times': spent_times,
         'current_category': category_filter,
         'search_query': search_query,
+        'week_offset': week_offset,
     })
 
 


### PR DESCRIPTION
## Summary
- show dates next to weekdays and add a Next Week link
- add timer controls and overtime display to weekly tasks
- style time display
- enhance daily task form with h/m/s inputs and styled edit form
- implement overtime counting for daily task timers

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687a978e46f48331996cee34842b082b