### PR TITLE
Add week navigation and edit form layout fix

### DIFF
--- a/tasks/templates/tasks/daily_tasks.html
+++ b/tasks/templates/tasks/daily_tasks.html
@@ -163,6 +163,21 @@
         .timer-display {
             margin-top: 5px;
             font-size: 13px;
+            background-color: #eef0f5;
+            color: #000;
+            padding: 4px 8px;
+            border-radius: 8px;
+            text-align: center;
+            display: inline-block;
+        }
+
+        .timer-section {
+            text-align: center;
+            margin-top: 10px;
+        }
+
+        .timer-label {
+            font-weight: bold;
         }
 
         .time-remain.expired {
@@ -171,7 +186,8 @@
 
         .overtime {
             color: red;
-            margin-left: 10px;
+            margin-top: 5px;
+            display: block;
         }
 
         .edit-form {
@@ -288,10 +304,12 @@
                 {{ form.goal_date }}
             </p>
 
-            <p>
-                <label for="{{ form.estimated_time.id_for_label }}">Estimated Time of Completion in Minutes:</label><br>
-                {{ form.estimated_time }}
-            </p>
+            <div class="time-input-group">
+                <label style="margin-right: 10px;">Estimated Duration:</label>
+                <input type="number" name="estimated_hours" min="0" placeholder="Hours">
+                <input type="number" name="estimated_minutes" min="0" max="59" placeholder="Minutes">
+                <input type="number" name="estimated_seconds" min="0" max="59" placeholder="Seconds">
+            </div>
 
             <p>
                 <label for="{{ form.category.id_for_label }}">Category:</label><br>
@@ -354,31 +372,62 @@
                     <div class="date-info">
                         {% if task.category %}Category: {{ task.category }}{% endif %}
                     </div>
-                </div>
 
-                <div class="action-buttons">
-                    <button class="edit-btn" onclick="toggleForm('edit-form-{{ task.id }}')">Edit</button>
-                    <form method="post" action="{% url 'delete_task' task.id %}" style="display:inline;">
-                        {% csrf_token %}
-                        <button type="submit" class="delete-btn">Delete</button>
-                    </form>
-                </div>
+                    <div class="action-buttons">
+                        <button class="edit-btn" onclick="toggleForm('edit-form-{{ task.id }}')">Edit</button>
+                        <form method="post" action="{% url 'delete_task' task.id %}" style="display:inline;">
+                            {% csrf_token %}
+                            <button type="submit" class="delete-btn">Delete</button>
+                        </form>
+                    </div>
 
-                <div id="edit-form-{{ task.id }}" class="edit-form" style="display: none;">
-                    <form method="post" action="{% url 'edit_task' task.id %}">
-                        {% csrf_token %}
-                        {{ edit_forms|dict_get:task.id|safe }}
-                        <button type="submit" class="save-btn">Save Changes</button>
-                    </form>
-                </div>
+                    <div id="edit-form-{{ task.id }}" class="edit-form task-form-container" style="display: none;">
+                        <form method="post" action="{% url 'edit_task' task.id %}">
+                            {% csrf_token %}
+                            <p>
+                                <label>Title:</label><br>
+                                <input type="text" name="title" value="{{ task.title }}">
+                            </p>
+                            <p>
+                                <label>Description:</label><br>
+                                <textarea name="description">{{ task.description }}</textarea>
+                            </p>
+                            <p>
+                                <label>Deadline:</label><br>
+                                <input type="date" name="deadline" value="{{ task.deadline|date:'Y-m-d' }}">
+                            </p>
+                            <p>
+                                <label>Goal date:</label><br>
+                                <input type="date" name="goal_date" value="{{ task.goal_date|date:'Y-m-d' }}">
+                            </p>
+                            <div class="time-input-group">
+                                <label style="margin-right: 10px;">Estimated Duration:</label>
+                                <input type="number" name="estimated_hours" min="0" value="{{ task.estimated_time|seconds_to_hours }}">
+                                <input type="number" name="estimated_minutes" min="0" max="59" value="{{ task.estimated_time|seconds_to_minutes }}">
+                                <input type="number" name="estimated_seconds" min="0" max="59" value="{{ task.estimated_time|seconds_to_seconds }}">
+                            </div>
+                            <p>
+                                <label>Category:</label><br>
+                                <input type="text" name="category" value="{{ task.category }}">
+                            </p>
+                            <p>
+                                <label>Category color:</label><br>
+                                <input type="color" name="category_color" value="{{ task.category_color }}">
+                            </p>
+                            <button type="submit" class="save-btn">Save Changes</button>
+                            <button type="button" class="delete-btn" onclick="toggleForm('edit-form-{{ task.id }}')">Cancel</button>
+                        </form>
+                    </div>
 
-                <!-- Timer Controls & Display -->
-                <div class="action-buttons" style="margin-top: 10px;">
-                    <button onclick="startTimer({{ task.id }}, {{ task.estimated_time|default:0 }})" class="add-task-btn">Start</button>
-                    <button onclick="pauseTimer({{ task.id }})" class="add-task-btn">Pause</button>
-                    <button onclick="stopTimer({{ task.id }}, {{ task.estimated_time|default:0 }})" class="delete-btn">Stop</button>
-                    <div id="timer-display-{{ task.id }}" class="timer-display" style="margin-top: 5px;">
-                        Time Remaining: {{ task.estimated_time|default:"00" }}:00:00
+                    <div class="timer-section">
+                        <div class="timer-label">Time Remaining</div>
+                        <div id="timer-display-{{ task.id }}" class="timer-display">{{ task.estimated_time|seconds_to_hms }}</div>
+                        <span id="overtime-display-{{ task.id }}" class="overtime" style="display:none;"></span>
+                        <div class="action-buttons" style="margin-top: 10px;">
+                            <button onclick="startTimer({{ task.id }}, {{ task.estimated_time|default:0 }})" class="add-task-btn">Start</button>
+                            <button onclick="pauseTimer({{ task.id }})" class="add-task-btn">Pause</button>
+                            <button onclick="stopTimer({{ task.id }}, {{ task.estimated_time|default:0 }})" class="delete-btn">Stop</button>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -422,11 +471,41 @@
                         </form>
                     </div>
 
-                    <div id="edit-form-{{ task.id }}" class="edit-form" style="display: none;">
+                    <div id="edit-form-{{ task.id }}" class="edit-form task-form-container" style="display: none;">
                         <form method="post" action="{% url 'edit_task' task.id %}">
                             {% csrf_token %}
-                            {{ edit_forms|dict_get:task.id|safe }}
+                            <p>
+                                <label>Title:</label><br>
+                                <input type="text" name="title" value="{{ task.title }}">
+                            </p>
+                            <p>
+                                <label>Description:</label><br>
+                                <textarea name="description">{{ task.description }}</textarea>
+                            </p>
+                            <p>
+                                <label>Deadline:</label><br>
+                                <input type="date" name="deadline" value="{{ task.deadline|date:'Y-m-d' }}">
+                            </p>
+                            <p>
+                                <label>Goal date:</label><br>
+                                <input type="date" name="goal_date" value="{{ task.goal_date|date:'Y-m-d' }}">
+                            </p>
+                            <div class="time-input-group">
+                                <label style="margin-right: 10px;">Estimated Duration:</label>
+                                <input type="number" name="estimated_hours" min="0" value="{{ task.estimated_time|seconds_to_hours }}">
+                                <input type="number" name="estimated_minutes" min="0" max="59" value="{{ task.estimated_time|seconds_to_minutes }}">
+                                <input type="number" name="estimated_seconds" min="0" max="59" value="{{ task.estimated_time|seconds_to_seconds }}">
+                            </div>
+                            <p>
+                                <label>Category:</label><br>
+                                <input type="text" name="category" value="{{ task.category }}">
+                            </p>
+                            <p>
+                                <label>Category color:</label><br>
+                                <input type="color" name="category_color" value="{{ task.category_color }}">
+                            </p>
                             <button type="submit" class="save-btn">Save Changes</button>
+                            <button type="button" class="delete-btn" onclick="toggleForm('edit-form-{{ task.id }}')">Cancel</button>
                         </form>
                     </div>
                 </div>
@@ -446,6 +525,8 @@
         }
     }
 
+    const taskTitles = JSON.parse('{{ task_titles_json|escapejs }}');
+
     // Format seconds as hh:mm:ss
     function formatTime(seconds) {
         const h = String(Math.floor(seconds / 3600)).padStart(2, '0');
@@ -455,7 +536,7 @@
     }
 
     // Timer state and intervals for countdown timers
-    const timers = {};  // taskId: {remainingSeconds, intervalId}
+    const timers = {};  // taskId: {remainingSeconds, intervalId, notified}
 
     // Load timer states from localStorage
     function loadTimers() {
@@ -467,7 +548,10 @@
     function saveTimers() {
         const state = {};
         for (const taskId in timers) {
-            state[taskId] = { remainingSeconds: timers[taskId].remainingSeconds };
+            state[taskId] = {
+                remainingSeconds: timers[taskId].remainingSeconds,
+                notified: timers[taskId].notified
+            };
         }
         localStorage.setItem('countdownTimers', JSON.stringify(state));
     }
@@ -475,24 +559,34 @@
     // Update timer display for a task
     function updateDisplay(taskId) {
         const display = document.getElementById(`timer-display-${taskId}`);
+        const overtimeEl = document.getElementById(`overtime-display-${taskId}`);
         if (!display) return;
         const remaining = timers[taskId]?.remainingSeconds ?? 0;
-        if (remaining > 0) {
-            display.textContent = `Time Remaining: ${formatTime(remaining)}`;
+        if (remaining >= 0) {
+            display.textContent = formatTime(remaining);
             display.classList.remove('expired');
+            if (overtimeEl) overtimeEl.style.display = 'none';
         } else {
-            display.textContent = "Time's Up!";
-            display.classList.add('expired');
+            if (!timers[taskId].notified) {
+                const name = taskTitles[taskId] || `Task ${taskId}`;
+                alert(`Time's up for ${name}! Click OK to continue working and enter overtime.`);
+                timers[taskId].notified = true;
+                display.classList.add('expired');
+                display.textContent = '00:00:00';
+                if (overtimeEl) overtimeEl.style.display = 'block';
+            }
+            if (overtimeEl) overtimeEl.textContent = 'Overtime: ' + formatTime(-remaining);
         }
     }
 
     // Start countdown timer
-    function startTimer(taskId, estMinutes) {
+    function startTimer(taskId, estSeconds) {
         if (timers[taskId]?.intervalId) return; // Already running
 
         if (!timers[taskId]) {
             timers[taskId] = {
-                remainingSeconds: estMinutes * 60
+                remainingSeconds: estSeconds,
+                notified: false
             };
         }
 
@@ -501,12 +595,6 @@
         timers[taskId].intervalId = setInterval(() => {
             timers[taskId].remainingSeconds--;
             updateDisplay(taskId);
-
-            if (timers[taskId].remainingSeconds <= 0) {
-                clearInterval(timers[taskId].intervalId);
-                timers[taskId].intervalId = null;
-                alert(`Task ${taskId} time is up!`);
-            }
             saveTimers();
         }, 1000);
 
@@ -523,13 +611,13 @@
     }
 
     // Stop countdown timer and reset
-function stopTimer(taskId, estMinutes) {
+function stopTimer(taskId, estSeconds) {
     if (timers[taskId]?.intervalId) {
         clearInterval(timers[taskId].intervalId);
     }
 
     // Calculate elapsed time before resetting
-    const originalSeconds = estMinutes * 60;
+    const originalSeconds = estSeconds;
     const remaining = timers[taskId]?.remainingSeconds ?? originalSeconds;
     const elapsed = originalSeconds - remaining;
 
@@ -540,8 +628,11 @@ function stopTimer(taskId, estMinutes) {
     // Reset timer state
     timers[taskId] = {
         remainingSeconds: originalSeconds,
-        intervalId: null
+        intervalId: null,
+        notified: false
     };
+    const overEl = document.getElementById(`overtime-display-${taskId}`);
+    if (overEl) overEl.style.display = 'none';
 
     updateDisplay(taskId);
     saveTimers();
@@ -552,14 +643,18 @@ function stopTimer(taskId, estMinutes) {
     window.addEventListener('load', () => {
         const storedTimers = loadTimers();
         for (const taskId in storedTimers) {
-            timers[taskId] = { remainingSeconds: storedTimers[taskId].remainingSeconds, intervalId: null };
+            timers[taskId] = {
+                remainingSeconds: storedTimers[taskId].remainingSeconds,
+                intervalId: null,
+                notified: storedTimers[taskId].notified
+            };
             updateDisplay(taskId);
         }
     });
 
 // Get elapsed time in seconds for a task
-    function getElapsedTime(taskId, estMinutes) {
-        const originalSeconds = estMinutes * 60;
+    function getElapsedTime(taskId, estSeconds) {
+        const originalSeconds = estSeconds;
         const remaining = timers[taskId]?.remainingSeconds ?? originalSeconds;
         const elapsed = originalSeconds - remaining;
     return elapsed; // in seconds

--- a/tasks/templates/tasks/weekly_tasks.html
+++ b/tasks/templates/tasks/weekly_tasks.html
@@ -159,9 +159,23 @@
             font-size: 16px;
         }
 
+        .timer-section {
+            text-align: center;
+            margin-top: 10px;
+        }
+
+        .timer-label {
+            font-weight: bold;
+        }
+
         .timer-display {
             margin-top: 5px;
             font-size: 13px;
+            background-color: #eef0f5;
+            color: #000;
+            padding: 4px 8px;
+            border-radius: 8px;
+            display: inline-block;
         }
 
         .time-remain.expired {
@@ -170,7 +184,8 @@
 
         .overtime {
             color: red;
-            margin-left: 10px;
+            margin-top: 5px;
+            display: block;
         }
 
         .edit-form {
@@ -311,11 +326,18 @@
     </div>
 
     {% for day, tasks in tasks_by_day.items %}
-        <div class="day-header">{{ day }}</div>
+        <div class="day-header">{{ day }} - {{ week_day_dates|dict_get:day|date:"F j, Y" }}</div>
         {% for task in tasks %}
             <div class="task-card {% if task.is_completed %}completed{% endif %}">
+                <form method="post" action="{% url 'toggle_task_complete' task.id %}">
+                    {% csrf_token %}
+                    <button type="submit" class="check-circle {% if task.is_completed %}completed{% endif %}" title="Toggle complete">
+                        {% if task.is_completed %}<span>✔</span>{% endif %}
+                    </button>
+                </form>
+
+                <div class="category-symbol" style="color: {{ task.category_color }}">ᯓ★ˎˊ˗</div>
                 <div class="task-details">
-                    <div class="category-symbol" style="color: {{ task.category_color }}">ᯓ★ˎˊ˗</div>
                     <div class="task-title">{{ task.title }}</div>
                     <div class="task-desc">{{ task.description }}</div>
                     <div class="date-info">
@@ -326,7 +348,7 @@
                         {% with info=running_timers|dict_get:task.id %}
                             {% if info %}
                                 <div class="timer-display">
-                                    Time Remaining: <span id="timer-{{ task.id }}" class="time-remain"></span>
+                                    <span id="timer-{{ task.id }}" class="time-remain"></span>
                                     <span id="overtime-{{ task.id }}" class="overtime" style="display:none;"></span>
                                 </div>
                             {% endif %}
@@ -344,18 +366,52 @@
                     <div id="edit-form-{{ task.id }}" class="edit-form task-form-container">
                         <form method="post" action="{% url 'edit_task' task.id %}">
                             {% csrf_token %}
-                            {{ edit_forms|dict_get:task.id|safe }}
+                            <p>
+                                <label>Title:</label><br>
+                                <input type="text" name="title" value="{{ task.title }}">
+                            </p>
+                            <p>
+                                <label>Description:</label><br>
+                                <textarea name="description">{{ task.description }}</textarea>
+                            </p>
+                            <p>
+                                <label>Deadline:</label><br>
+                                <input type="date" name="deadline" value="{{ task.deadline|date:'Y-m-d' }}">
+                            </p>
+                            <p>
+                                <label>Goal date:</label><br>
+                                <input type="date" name="goal_date" value="{{ task.goal_date|date:'Y-m-d' }}">
+                            </p>
+                            <div class="time-input-group">
+                                <label style="margin-right: 10px;">Estimated Duration:</label>
+                                <input type="number" name="estimated_hours" min="0" value="{{ task.estimated_time|seconds_to_hours }}">
+                                <input type="number" name="estimated_minutes" min="0" max="59" value="{{ task.estimated_time|seconds_to_minutes }}">
+                                <input type="number" name="estimated_seconds" min="0" max="59" value="{{ task.estimated_time|seconds_to_seconds }}">
+                            </div>
+                            <p>
+                                <label>Category:</label><br>
+                                <input type="text" name="category" value="{{ task.category }}">
+                            </p>
+                            <p>
+                                <label>Category color:</label><br>
+                                <input type="color" name="category_color" value="{{ task.category_color }}">
+                            </p>
                             <button type="submit" class="save-btn">Save Changes</button>
                             <button type="button" class="delete-btn" onclick="toggleForm('edit-form-{{ task.id }}')">Cancel</button>
                         </form>
                     </div>
+
+                    <div class="timer-section">
+                        <div class="timer-label">Time Remaining</div>
+                        <div id="timer-display-{{ task.id }}" class="timer-display">{{ task.estimated_time|seconds_to_hms }}</div>
+                        <span id="overtime-display-{{ task.id }}" class="overtime" style="display:none;"></span>
+                        <div class="action-buttons" style="margin-top: 10px;">
+                            <button onclick="startTimer({{ task.id }}, {{ task.estimated_time|default:0 }})" class="add-task-btn">Start</button>
+                            <button onclick="pauseTimer({{ task.id }})" class="add-task-btn">Pause</button>
+                            <button onclick="stopTimer({{ task.id }}, {{ task.estimated_time|default:0 }})" class="delete-btn">Stop</button>
+                        </div>
+                    </div>
                 </div>
-                <form method="post" action="{% url 'toggle_task_complete' task.id %}">
-                    {% csrf_token %}
-                    <button type="submit" class="check-circle {% if task.is_completed %}completed{% endif %}" title="Toggle complete">
-                        {% if task.is_completed %}<span>✔</span>{% endif %}
-                    </button>
-                </form>
             </div>
         {% endfor %}
     {% endfor %}
@@ -363,8 +419,14 @@
     <h2 class="section-title">Completed Tasks</h2>
     {% for task in completed_tasks %}
         <div class="task-card completed">
+            <form method="post" action="{% url 'toggle_task_complete' task.id %}">
+                {% csrf_token %}
+                <button type="submit" class="check-circle completed" title="Mark as incomplete">
+                    <span>✔</span>
+                </button>
+            </form>
+            <div class="category-symbol" style="color: {{ task.category_color }}">ᯓ★ˎˊ˗</div>
             <div class="task-details">
-                <div class="category-symbol" style="color: {{ task.category_color }}">ᯓ★ˎˊ˗</div>
                 <div class="task-title">{{ task.title }}</div>
                 <div class="task-desc">{{ task.description }}</div>
                 <div class="date-info">
@@ -384,22 +446,50 @@
                 <div id="edit-form-{{ task.id }}" class="edit-form task-form-container">
                     <form method="post" action="{% url 'edit_task' task.id %}">
                         {% csrf_token %}
-                        {{ edit_forms|dict_get:task.id|safe }}
+                        <p>
+                            <label>Title:</label><br>
+                            <input type="text" name="title" value="{{ task.title }}">
+                        </p>
+                        <p>
+                            <label>Description:</label><br>
+                            <textarea name="description">{{ task.description }}</textarea>
+                        </p>
+                        <p>
+                            <label>Deadline:</label><br>
+                            <input type="date" name="deadline" value="{{ task.deadline|date:'Y-m-d' }}">
+                        </p>
+                        <p>
+                            <label>Goal date:</label><br>
+                            <input type="date" name="goal_date" value="{{ task.goal_date|date:'Y-m-d' }}">
+                        </p>
+                        <div class="time-input-group">
+                            <label style="margin-right: 10px;">Estimated Duration:</label>
+                            <input type="number" name="estimated_hours" min="0" value="{{ task.estimated_time|seconds_to_hours }}">
+                            <input type="number" name="estimated_minutes" min="0" max="59" value="{{ task.estimated_time|seconds_to_minutes }}">
+                            <input type="number" name="estimated_seconds" min="0" max="59" value="{{ task.estimated_time|seconds_to_seconds }}">
+                        </div>
+                        <p>
+                            <label>Category:</label><br>
+                            <input type="text" name="category" value="{{ task.category }}">
+                        </p>
+                        <p>
+                            <label>Category color:</label><br>
+                            <input type="color" name="category_color" value="{{ task.category_color }}">
+                        </p>
                         <button type="submit" class="save-btn">Save Changes</button>
                         <button type="button" class="delete-btn" onclick="toggleForm('edit-form-{{ task.id }}')">Cancel</button>
                     </form>
                 </div>
             </div>
-            <form method="post" action="{% url 'toggle_task_complete' task.id %}">
-                {% csrf_token %}
-                <button type="submit" class="check-circle completed" title="Mark as incomplete">
-                    <span>✔</span>
-                </button>
-            </form>
         </div>
     {% empty %}
         <p>No tasks completed this week.</p>
     {% endfor %}
+</div>
+
+<div style="text-align:center; margin-top: 20px;">
+    <a href="?week={{ week_offset|add:-1 }}" class="add-task-btn" style="margin-right: 10px;">Previous Week</a>
+    <a href="?week={{ week_offset|add:1 }}" class="add-task-btn">Next Week</a>
 </div>
 
 </div>
@@ -415,6 +505,7 @@
     }
 
     const runningTimers = JSON.parse('{{ running_timers_json|escapejs }}');
+    const taskTitles = JSON.parse('{{ task_titles_json|escapejs }}');
     function formatTime(sec) {
         const h = String(Math.floor(sec / 3600)).padStart(2, '0');
         const m = String(Math.floor((sec % 3600) / 60)).padStart(2, '0');
@@ -433,7 +524,8 @@
             const remaining = est - elapsed;
             if (remaining <= 0) {
                 if (!remEl.dataset.notified) {
-                    alert('Your time is up! Click Ok to continue working');
+                    const name = data.title || ('Task ' + data.id);
+                    alert(`Time's up for ${name}! Click OK to continue working and enter overtime.`);
                     remEl.dataset.notified = 'true';
                     remEl.classList.add('expired');
                     remEl.textContent = '00:00:00';
@@ -452,6 +544,87 @@
         for (const [id, data] of Object.entries(runningTimers)) {
             const el = document.getElementById('timer-' + id);
             if (el) startCountdown(el, { ...data, id: id });
+        }
+    });
+
+    // Local countdown timers for Start/Pause/Stop buttons
+    const timers = {};
+
+    function loadTimers() {
+        const stored = localStorage.getItem('weeklyCountdowns');
+        return stored ? JSON.parse(stored) : {};
+    }
+
+    function saveTimers() {
+        const state = {};
+        for (const id in timers) {
+            state[id] = { remainingSeconds: timers[id].remainingSeconds, notified: timers[id].notified };
+        }
+        localStorage.setItem('weeklyCountdowns', JSON.stringify(state));
+    }
+
+    function updateDisplay(id) {
+        const remEl = document.getElementById('timer-display-' + id) || document.getElementById('timer-' + id);
+        const overEl = document.getElementById('overtime-display-' + id) || document.getElementById('overtime-' + id);
+        if (!remEl) return;
+        const remaining = timers[id]?.remainingSeconds ?? 0;
+        if (remaining >= 0) {
+            remEl.textContent = formatTime(remaining);
+            remEl.classList.remove('expired');
+            if (overEl) overEl.style.display = 'none';
+        } else {
+            if (!timers[id].notified) {
+                const name = taskTitles[id] || ('Task ' + id);
+                alert(`Time's up for ${name}! Click OK to continue working and enter overtime.`);
+                timers[id].notified = true;
+                remEl.classList.add('expired');
+                remEl.textContent = '00:00:00';
+                if (overEl) overEl.style.display = 'block';
+            }
+            if (overEl) overEl.textContent = 'Overtime: ' + formatTime(-remaining);
+        }
+    }
+
+    function startTimer(id, est) {
+        if (timers[id]?.intervalId) return;
+
+        if (!timers[id]) {
+            timers[id] = { remainingSeconds: est, intervalId: null, notified: false };
+        }
+
+        updateDisplay(id);
+        timers[id].intervalId = setInterval(() => {
+            timers[id].remainingSeconds--;
+            updateDisplay(id);
+            saveTimers();
+        }, 1000);
+        saveTimers();
+    }
+
+    function pauseTimer(id) {
+        if (timers[id]?.intervalId) {
+            clearInterval(timers[id].intervalId);
+            timers[id].intervalId = null;
+            saveTimers();
+        }
+    }
+
+    function stopTimer(id, est) {
+        if (timers[id]?.intervalId) {
+            clearInterval(timers[id].intervalId);
+        }
+        timers[id] = { remainingSeconds: est, intervalId: null, notified: false };
+        const overEl = document.getElementById('overtime-display-' + id) || document.getElementById('overtime-' + id);
+        if (overEl) overEl.style.display = 'none';
+        updateDisplay(id);
+        saveTimers();
+    }
+
+    window.addEventListener('load', () => {
+        const stored = loadTimers();
+        for (const id in stored) {
+            timers[id] = { remainingSeconds: stored[id].remainingSeconds, intervalId: null, notified: stored[id].notified };
+            updateDisplay(id);
         }
     });
 </script>

--- a/tasks/templatetags/custom_filters.py
+++ b/tasks/templatetags/custom_filters.py
@@ -29,3 +29,24 @@ def minutes_to_hms(value):
         return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
     except (TypeError, ValueError):
         return ''
+
+@register.filter
+def seconds_to_hours(value):
+    try:
+        return int(value) // 3600
+    except (TypeError, ValueError):
+        return 0
+
+@register.filter
+def seconds_to_minutes(value):
+    try:
+        return (int(value) % 3600) // 60
+    except (TypeError, ValueError):
+        return 0
+
+@register.filter
+def seconds_to_seconds(value):
+    try:
+        return int(value) % 60
+    except (TypeError, ValueError):
+        return 0


### PR DESCRIPTION
## Summary
- adjust daily edit form and timer section layout
- style timer section and keep content within task details
- add Previous Week navigation link
- improve edit forms with hours/minutes/seconds
- show clearer alert messages when time is up

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_687a978e46f48331996cee34842b082b